### PR TITLE
Fix compilation errors in upload controller

### DIFF
--- a/src/main/java/com/example/packinglist/controller/UploadController.java
+++ b/src/main/java/com/example/packinglist/controller/UploadController.java
@@ -235,13 +235,13 @@ public class UploadController {
             
             // Configure recognition settings for better accuracy
             RecognitionSettings settings = new RecognitionSettings();
-            settings.setLanguage(com.aspose.ocr.Language.Eng);
+            // Language setting - using auto-detection or default language
             
             // Perform OCR recognition
             ArrayList<RecognitionResult> results = api.Recognize(input, settings);
             
             if (results != null && !results.isEmpty()) {
-                String text = results.get(0).recognition_text;
+                String text = results.get(0).recognitionText;
                 if (text != null) {
                     // Extract UPS tracking number pattern: 1Z followed by 16 alphanumeric characters
                     Matcher matcher = Pattern.compile("1Z[0-9A-Z]{16}").matcher(text.toUpperCase());


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix Aspose OCR API usage to resolve compilation errors due to API changes in version 25.6.0.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `com.aspose.ocr.Language` class was removed/changed in Aspose OCR 25.6.0, causing a "cannot find symbol" error. Removing the explicit language setting allows the OCR to use default auto-detection. Additionally, the `recognition_text` field in `RecognitionResult` was renamed to `recognitionText`, which also caused a "cannot find symbol" error.

---
<a href="https://cursor.com/background-agent?bcId=bc-13532615-4333-4c99-8fb3-13d923c3fae8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-13532615-4333-4c99-8fb3-13d923c3fae8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>