### PR TITLE
Fix docker image not found error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,11 @@ COPY src src
 RUN ./mvnw clean package -DskipTests
 
 # Stage 2: Runtime container
-FROM eclipse-temurin:17-jdk-slim
+FROM eclipse-temurin:17-jre
+# Alternative options if the above doesn't work:
+# FROM openjdk:17-jre-slim
+# FROM eclipse-temurin:17
+# FROM amazoncorretto:17
 
 RUN apt-get update && apt-get install -y \
     fontconfig \


### PR DESCRIPTION
Update Docker base image to `eclipse-temurin:17-jre` to resolve `eclipse-temurin:17-jdk-slim: not found` deployment error.

---
<a href="https://cursor.com/background-agent?bcId=bc-d61c049d-a0d5-48d9-920c-bc8ae177b794">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d61c049d-a0d5-48d9-920c-bc8ae177b794">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>