### PR TITLE
Fix table header width error

### DIFF
--- a/src/main/java/com/example/packinglist/controller/UploadController.java
+++ b/src/main/java/com/example/packinglist/controller/UploadController.java
@@ -311,10 +311,8 @@ public class UploadController {
             writer.write("<tr>\n");
             writer.write("<th>PO#</th>\n");
             writer.write("<th>ITEM#</th>\n");
-            // writer.write("<th>QTY</th>\n");
-            // writer.write("<th></th>\n"); // Empty column
-            <th style="width: 50%;">QTY</th>
-            <th style="width: 50%;">&nbsp;</th>
+            writer.write("<th style=\"width: 50%;\">QTY</th>\n");
+            writer.write("<th style=\"width: 50%;\">&nbsp;</th>\n");
             writer.write("<th>NOTES</th>\n");
             writer.write("</tr>\n");
             


### PR DESCRIPTION
Add QTY and empty table headers, fixing a compilation error.

The error occurred because the HTML `<th>` tags were directly embedded in the Java code without being wrapped in `writer.write()` statements, leading to a compilation failure. This PR wraps them correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-04eddbdd-e278-48eb-aa62-a023e0ac8861">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-04eddbdd-e278-48eb-aa62-a023e0ac8861">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>