### PR TITLE
Format shipping data for single page display

### DIFF
--- a/src/main/java/com/example/packinglist/controller/UploadController.java
+++ b/src/main/java/com/example/packinglist/controller/UploadController.java
@@ -277,15 +277,16 @@ public class UploadController {
 
     public File generatePackingListHtml(String date, List<InvoiceEntry> invoiceEntries, String tracking, double weight, int boxes, double rmb, double rate) throws IOException {
         // Configure items per page (can be made configurable via parameter)
-        int itemsPerPage = 20; // 10 items per column × 2 columns per page
+        int itemsPerPage = 64; // 32 items per column × 2 columns per page
         return generatePackingListHtmlWithPagination(date, invoiceEntries, tracking, weight, boxes, rmb, rate, itemsPerPage);
     }
 
     /**
      * Generates a multi-page HTML packing list with configurable pagination.
      * Each page contains two columns: left column has first N items, right column has next N items.
+     * Header information (arrival, amount, date, PO#, UPS freight) appears once at the top.
      * 
-     * @param itemsPerPage Total items per page (will be split evenly between left and right columns)
+     * @param itemsPerPage Total items per page (will be split evenly between left and right columns, default 64 for 32 rows each)
      */
     public File generatePackingListHtmlWithPagination(String date, List<InvoiceEntry> invoiceEntries, String tracking, double weight, int boxes, double rmb, double rate, int itemsPerPage) throws IOException {
         String po = "W" + date;


### PR DESCRIPTION
Update packing list to display 32 rows per column and show header info once at the top.

The `itemsPerPage` was increased from 20 to 64 to accommodate 32 rows per column across two columns, fulfilling the user's request for a denser packing list format while maintaining the existing single-page, two-column layout and top-level header information.

---
<a href="https://cursor.com/background-agent?bcId=bc-67ae3561-2209-4f47-b7f6-d5151fe59706">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-67ae3561-2209-4f47-b7f6-d5151fe59706">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

