### PR TITLE
Format table with specific font sizes and line breaks

### DIFF
--- a/display_output.html
+++ b/display_output.html
@@ -24,8 +24,8 @@ td, th { padding: 2px 4px; vertical-align: top; }
 .table-column { flex: 1; }
 .data-table { width: 100%; border: 2px solid #000; }
 .data-table th { border: 1px solid #000; background-color: #f0f0f0; font-weight: bold; text-align: center; padding: 3px; font-size: 10px; }
-.data-table th.item-header, .data-table th.qty-header { font-size: 16px; }
 .data-table td { border: 1px solid #000; text-align: center; padding: 2px; font-size: 8px; }
+.data-table td.item-data, .data-table td.qty-data { font-size: 16px; }
 .duplicate-item { border: 3px solid red; border-radius: 50%; }
 .po-col { width: 15%; }
 .item-col { width: 25%; }
@@ -47,10 +47,14 @@ td, th { padding: 2px 4px; vertical-align: top; }
 </div>
 <div class="header-row">
 <span class="header-label">P.O.#W250814=>AMNT:</span>
+</div>
+<div class="header-row">
 <span class="header-value"></span>
 </div>
 <div class="header-row">
 <span class="header-label">P.O.#WONA250814,8%DISC$321.07=>AMNT:</span>
+</div>
+<div class="header-row">
 <span class="header-value"></span>
 </div>
 </div>
@@ -76,43 +80,43 @@ td, th { padding: 2px 4px; vertical-align: top; }
 <table class="data-table">
 <tr>
 <th class="po-col">PO/NO</th>
-<th class="item-col item-header">ITEM NO.</th>
-<th class="qty-col qty-header">QTY</th>
+<th class="item-col">ITEM NO.</th>
+<th class="qty-col">QTY</th>
 <th class="receive-check-col">RECEIVE CHECK</th>
 <th class="notes-col">NOTES</th>
 </tr>
 <tr>
 <td>W240613</td>
-<td class="duplicate-item">1015</td>
-<td>24</td>
+<td class="duplicate-item item-data">1015</td>
+<td class="qty-data">24</td>
 <td><input type="checkbox"></td>
 <td></td>
 </tr>
 <tr>
 <td>W250626</td>
-<td class="duplicate-item">1015</td>
-<td>12</td>
+<td class="duplicate-item item-data">1015</td>
+<td class="qty-data">12</td>
 <td><input type="checkbox"></td>
 <td></td>
 </tr>
 <tr>
 <td>W250606</td>
-<td class="duplicate-item">1015</td>
-<td>6</td>
+<td class="duplicate-item item-data">1015</td>
+<td class="qty-data">6</td>
 <td><input type="checkbox"></td>
 <td></td>
 </tr>
 <tr>
 <td>W240613</td>
-<td class="duplicate-item">1016B</td>
-<td>36</td>
+<td class="duplicate-item item-data">1016B</td>
+<td class="qty-data">36</td>
 <td><input type="checkbox"></td>
 <td></td>
 </tr>
 <tr>
 <td>W250633</td>
-<td class="duplicate-item">1016B</td>
-<td>18</td>
+<td class="duplicate-item item-data">1016B</td>
+<td class="qty-data">18</td>
 <td><input type="checkbox"></td>
 <td></td>
 </tr>
@@ -122,43 +126,43 @@ td, th { padding: 2px 4px; vertical-align: top; }
 <table class="data-table">
 <tr>
 <th class="po-col">PO/NO</th>
-<th class="item-col item-header">ITEM NO.</th>
-<th class="qty-col qty-header">QTY</th>
+<th class="item-col">ITEM NO.</th>
+<th class="qty-col">QTY</th>
 <th class="receive-check-col">RECEIVE CHECK</th>
 <th class="notes-col">NOTES</th>
 </tr>
 <tr>
 <td>W250631</td>
-<td>1022</td>
-<td>60</td>
+<td class="item-data">1022</td>
+<td class="qty-data">60</td>
 <td><input type="checkbox"></td>
 <td></td>
 </tr>
 <tr>
 <td>W250631</td>
-<td>1037B</td>
-<td>120</td>
+<td class="item-data">1037B</td>
+<td class="qty-data">120</td>
 <td><input type="checkbox"></td>
 <td></td>
 </tr>
 <tr>
 <td>W250633</td>
-<td>1069B</td>
-<td>144</td>
+<td class="item-data">1069B</td>
+<td class="qty-data">144</td>
 <td><input type="checkbox"></td>
 <td></td>
 </tr>
 <tr>
 <td>W250634</td>
-<td>1081G</td>
-<td>72</td>
+<td class="item-data">1081G</td>
+<td class="qty-data">72</td>
 <td><input type="checkbox"></td>
 <td></td>
 </tr>
 <tr>
 <td>W250631</td>
-<td>1098B</td>
-<td>36</td>
+<td class="item-data">1098B</td>
+<td class="qty-data">36</td>
 <td><input type="checkbox"></td>
 <td></td>
 </tr>

--- a/packing-list-250814.html
+++ b/packing-list-250814.html
@@ -24,8 +24,8 @@ td, th { padding: 2px 4px; vertical-align: top; }
 .table-column { flex: 1; }
 .data-table { width: 100%; border: 2px solid #000; }
 .data-table th { border: 1px solid #000; background-color: #f0f0f0; font-weight: bold; text-align: center; padding: 3px; font-size: 10px; }
-.data-table th.item-header, .data-table th.qty-header { font-size: 16px; }
 .data-table td { border: 1px solid #000; text-align: center; padding: 2px; font-size: 8px; }
+.data-table td.item-data, .data-table td.qty-data { font-size: 16px; }
 .duplicate-item { border: 3px solid red; border-radius: 50%; }
 .po-col { width: 15%; }
 .item-col { width: 25%; }
@@ -47,10 +47,14 @@ td, th { padding: 2px 4px; vertical-align: top; }
 </div>
 <div class="header-row">
 <span class="header-label">P.O.#W250814=>AMNT:</span>
+</div>
+<div class="header-row">
 <span class="header-value"></span>
 </div>
 <div class="header-row">
 <span class="header-label">P.O.#WONA250814,8%DISC$321.07=>AMNT:</span>
+</div>
+<div class="header-row">
 <span class="header-value"></span>
 </div>
 </div>
@@ -76,43 +80,43 @@ td, th { padding: 2px 4px; vertical-align: top; }
 <table class="data-table">
 <tr>
 <th class="po-col">PO/NO</th>
-<th class="item-col item-header">ITEM NO.</th>
-<th class="qty-col qty-header">QTY</th>
+<th class="item-col">ITEM NO.</th>
+<th class="qty-col">QTY</th>
 <th class="receive-check-col">RECEIVE CHECK</th>
 <th class="notes-col">NOTES</th>
 </tr>
 <tr>
 <td>W240613</td>
-<td class="duplicate-item">1015</td>
-<td>24</td>
+<td class="duplicate-item item-data">1015</td>
+<td class="qty-data">24</td>
 <td><input type="checkbox"></td>
 <td></td>
 </tr>
 <tr>
 <td>W250626</td>
-<td class="duplicate-item">1015</td>
-<td>12</td>
+<td class="duplicate-item item-data">1015</td>
+<td class="qty-data">12</td>
 <td><input type="checkbox"></td>
 <td></td>
 </tr>
 <tr>
 <td>W250606</td>
-<td class="duplicate-item">1015</td>
-<td>6</td>
+<td class="duplicate-item item-data">1015</td>
+<td class="qty-data">6</td>
 <td><input type="checkbox"></td>
 <td></td>
 </tr>
 <tr>
 <td>W240613</td>
-<td class="duplicate-item">1016B</td>
-<td>36</td>
+<td class="duplicate-item item-data">1016B</td>
+<td class="qty-data">36</td>
 <td><input type="checkbox"></td>
 <td></td>
 </tr>
 <tr>
 <td>W250633</td>
-<td class="duplicate-item">1016B</td>
-<td>18</td>
+<td class="duplicate-item item-data">1016B</td>
+<td class="qty-data">18</td>
 <td><input type="checkbox"></td>
 <td></td>
 </tr>
@@ -122,43 +126,43 @@ td, th { padding: 2px 4px; vertical-align: top; }
 <table class="data-table">
 <tr>
 <th class="po-col">PO/NO</th>
-<th class="item-col item-header">ITEM NO.</th>
-<th class="qty-col qty-header">QTY</th>
+<th class="item-col">ITEM NO.</th>
+<th class="qty-col">QTY</th>
 <th class="receive-check-col">RECEIVE CHECK</th>
 <th class="notes-col">NOTES</th>
 </tr>
 <tr>
 <td>W250631</td>
-<td>1022</td>
-<td>60</td>
+<td class="item-data">1022</td>
+<td class="qty-data">60</td>
 <td><input type="checkbox"></td>
 <td></td>
 </tr>
 <tr>
 <td>W250631</td>
-<td>1037B</td>
-<td>120</td>
+<td class="item-data">1037B</td>
+<td class="qty-data">120</td>
 <td><input type="checkbox"></td>
 <td></td>
 </tr>
 <tr>
 <td>W250633</td>
-<td>1069B</td>
-<td>144</td>
+<td class="item-data">1069B</td>
+<td class="qty-data">144</td>
 <td><input type="checkbox"></td>
 <td></td>
 </tr>
 <tr>
 <td>W250634</td>
-<td>1081G</td>
-<td>72</td>
+<td class="item-data">1081G</td>
+<td class="qty-data">72</td>
 <td><input type="checkbox"></td>
 <td></td>
 </tr>
 <tr>
 <td>W250631</td>
-<td>1098B</td>
-<td>36</td>
+<td class="item-data">1098B</td>
+<td class="qty-data">36</td>
 <td><input type="checkbox"></td>
 <td></td>
 </tr>


### PR DESCRIPTION
Updated HTML styling to standardize header font sizes, enlarge item and quantity cell fonts, and ensure P.O. amounts appear on new lines for improved readability.

---
<a href="https://cursor.com/background-agent?bcId=bc-822f076f-7602-48b6-944f-07b6e380a828">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-822f076f-7602-48b6-944f-07b6e380a828">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

